### PR TITLE
pwntoolsで外部アーキテクチャのバイナリを実行できるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
   python3 python3-dev python3-pip python3-gmpy2\
   virtualenv \
   wget \
-  ruby
+  ruby \
+  qemu-user
 
 WORKDIR /sandbox
 


### PR DESCRIPTION
`pwntools`を使っている時に以下のエラーに遭遇したため、`qemu-user`をインストールする。
```
[ERROR] Neither 'qemu-x86_64' nor 'qemu-x86_64-static' are available
```
https://docs.pwntools.com/en/stable/qemu.html#required-setup